### PR TITLE
Cleanup v2 (workflow outputs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Check out the `examples` directory for example pipelines that demonstrate how to
 
 **`boost.cleanup`**
 
-Set to `true` to enable automatic cleanup (default: `false`).
+Set to `true` to enable automatic cleanup (default: `false`). Temporary files will be automatically deleted as soon as they are no longer needed.
 
-Temporary files will be automatically deleted as soon as they are no longer needed. Additionally, each task directory will be deleted as soon as the task outputs are no longer needed.
+The default cleanup observer uses `publishDir` directives to determine whether a file should be published before it is deleted. Setting `boost.cleanup = 'v2'` will use an alternate cleanup observer which uses the new workflow publish definition instead of `publishDir` to track publishing.
 
 Limitations:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ boost {
 
 The plugin requires Nextflow version `23.10.0` or later.
 
+*New in version `0.4.0`: requires Nextflow `24.04.0` or later.*
+
 If a release hasn't been published to the main registry yet, you can still use it by specifying the following environment variable so that Nextflow can find the plugin:
 
 ```bash

--- a/examples/cleanup.nf
+++ b/examples/cleanup.nf
@@ -1,84 +1,111 @@
 
-params.bam_count = 10
-params.bam_size = '100M'
-params.sleep_mean = 10
-params.sleep_std = 3
+nextflow.preview.output = true
 
-rng = new Random()
+def randomInt() {
+  Math.random() * Integer.MAX_VALUE
+}
 
 process BAM1 {
-    input:
-    val index
+  input:
+  val index
+  val sleep_mean
+  val sleep_std
+  val bam_size
 
-    output:
-    tuple val(index), path("${index}-1.bam"), emit: bam
-    path "${index}-1.log", emit: log
+  output:
+  tuple val(index), path("${index}-1.bam"), emit: bam
+  path "${index}-1.log", emit: log
 
-    script:
-    """
-    sleep ${params.sleep_mean + rng.nextInt() % params.sleep_std}
-    dd if=/dev/random of=${index}-1.bam bs=1 count=0 seek=${params.bam_size}
-    echo "Wrote ${params.bam_size} to ${index}-1.bam" > ${index}-1.log
-    """
+  script:
+  """
+  sleep ${sleep_mean + randomInt() % sleep_std}
+  dd if=/dev/random of=${index}-1.bam bs=1 count=0 seek=${bam_size}
+  echo "Wrote ${bam_size} to ${index}-1.bam" > ${index}-1.log
+  """
 }
 
 process BAM2 {
-    input:
-    tuple val(index), path("${index}-1.bam")
+  input:
+  tuple val(index), path("${index}-1.bam")
+  val sleep_mean
+  val sleep_std
 
-    output:
-    tuple val(index), path("${index}-2.bam"), emit: bam
-    path "${index}-2.log", emit: log
+  output:
+  tuple val(index), path("${index}-2.bam"), emit: bam
+  path "${index}-2.log", emit: log
 
-    script:
-    """
-    sleep ${params.sleep_mean + rng.nextInt() % params.sleep_std}
-    cp ${index}-1.bam ${index}-2.bam
-    echo "Copied ${index}-1.bam to ${index}-2.bam" > ${index}-2.log
-    """
+  script:
+  """
+  sleep ${sleep_mean + randomInt() % sleep_std}
+  cp ${index}-1.bam ${index}-2.bam
+  echo "Copied ${index}-1.bam to ${index}-2.bam" > ${index}-2.log
+  """
 }
 
 process BAM3 {
-    publishDir 'results', pattern: '*.bam'
+  input:
+  tuple val(index), path("${index}-2.bam")
+  val sleep_mean
+  val sleep_std
 
-    input:
-    tuple val(index), path("${index}-2.bam")
+  output:
+  tuple val(index), path("${index}-3.bam"), emit: bam
+  path "${index}-3.log", emit: log
 
-    output:
-    tuple val(index), path("${index}-3.bam"), emit: bam
-    path "${index}-3.log", emit: log
-
-    script:
-    """
-    sleep ${params.sleep_mean + rng.nextInt() % params.sleep_std}
-    cp ${index}-2.bam ${index}-3.bam
-    echo "Copied ${index}-2.bam to ${index}-3.bam" > ${index}-3.log
-    """
+  script:
+  """
+  sleep ${sleep_mean + randomInt() % sleep_std}
+  cp ${index}-2.bam ${index}-3.bam
+  echo "Copied ${index}-2.bam to ${index}-3.bam" > ${index}-3.log
+  """
 }
 
 process SUMMARY {
-    publishDir 'results'
+  input:
+  path logs
+  val sleep_mean
+  val sleep_std
 
-    input:
-    path logs
+  output:
+  path 'summary.txt'
 
-    output:
-    path 'summary.txt'
-
-    script:
-    """
-    sleep ${params.sleep_mean + rng.nextInt() % params.sleep_std}
-    cat ${logs} > summary.txt
-    """
+  script:
+  """
+  sleep ${sleep_mean + randomInt() % sleep_std}
+  cat ${logs} > summary.txt
+  """
 }
 
 workflow {
-    BAM1( Channel.of( 1..params.bam_count ) )
-    BAM2(BAM1.out.bam)
-    BAM3(BAM2.out.bam)
+  main:
+  params.bam_count = 10
+  params.bam_size = '100M'
+  params.sleep_mean = 10
+  params.sleep_std = 3
 
-    BAM1.out.log
+  BAM1( Channel.of( 1..params.bam_count ), params.sleep_mean, params.sleep_std, params.bam_size )
+  BAM2(BAM1.out.bam, params.sleep_mean, params.sleep_std)
+  BAM3(BAM2.out.bam, params.sleep_mean, params.sleep_std)
+
+  ch_logs = BAM1.out.log
     | mix(BAM2.out.log, BAM3.out.log)
     | collect
-    | SUMMARY
+
+  SUMMARY(ch_logs, params.sleep_mean, params.sleep_std)
+
+  publish:
+  BAM3.out.bam >> 'bam'
+  SUMMARY.out >> 'summary'
+}
+
+output {
+  directory 'results'
+
+  'bam' {
+    path '.'
+  }
+
+  'summary' {
+    path '.'
+  }
 }

--- a/plugins/nf-boost/build.gradle
+++ b/plugins/nf-boost/build.gradle
@@ -56,7 +56,7 @@ sourceSets {
 
 dependencies {
     // This dependency is exported to consumers, that is to say found on their compile classpath.
-    compileOnly 'io.nextflow:nextflow:23.10.0'
+    compileOnly 'io.nextflow:nextflow:24.04.3'
     compileOnly 'org.slf4j:slf4j-api:1.7.10'
     compileOnly 'org.pf4j:pf4j:3.4.1'
     // add here plugins depepencies
@@ -64,7 +64,7 @@ dependencies {
     // test configuration
     testImplementation "org.codehaus.groovy:groovy:3.0.19"
     testImplementation "org.codehaus.groovy:groovy-nio:3.0.19"
-    testImplementation 'io.nextflow:nextflow:23.10.0'
+    testImplementation 'io.nextflow:nextflow:24.04.3'
     testImplementation ("org.codehaus.groovy:groovy-test:3.0.19") { exclude group: 'org.codehaus.groovy' }
     testImplementation ("cglib:cglib-nodep:3.3.0")
     testImplementation ("org.objenesis:objenesis:3.1")

--- a/plugins/nf-boost/src/main/nextflow/boost/BoostObserverFactory.groovy
+++ b/plugins/nf-boost/src/main/nextflow/boost/BoostObserverFactory.groovy
@@ -20,6 +20,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.boost.cleanup.CleanupObserver
+import nextflow.boost.cleanup.CleanupObserverV2
 import nextflow.trace.TraceObserver
 import nextflow.trace.TraceObserverFactory
 
@@ -36,8 +37,14 @@ class BoostObserverFactory implements TraceObserverFactory {
     Collection<TraceObserver> create(Session session) {
         List<TraceObserver> result = []
 
-        if( session.config.navigate('boost.cleanup', false) )
+        final cleanup = session.config.navigate('boost.cleanup', false)
+        if( cleanup == true || cleanup == 'v1' )
             result << new CleanupObserver()
+        else if( cleanup == 'v2' )
+            result << new CleanupObserverV2()
+        else if( cleanup != false ) {
+            throw new IllegalArgumentException("Invalid `boost.cleanup` value -- ${cleanup}")
+        }
 
         return result
     }

--- a/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
+++ b/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
@@ -143,8 +143,10 @@ class CleanupObserverV2 implements TraceObserver {
                 }
 
                 // determine whether the output channel might be published
-                if( ch in session.publishTargets )
+                if( ch in session.publishTargets ) {
+                    log.trace "Process output `${process.name}/${i+1}` might be published"
                     publishable[i] = true
+                }
 
                 // check if output may forward input files
                 if( hasForwardedInputs(param) )
@@ -307,7 +309,7 @@ class CleanupObserverV2 implements TraceObserver {
         // get publishable outputs
         final publishableOutputs = getPublishableOutputs(task, outputs)
 
-        log.trace "[${task.name}] the following files may be published: ${publishableOutputs*.toUriString()}"
+        log.trace "[${task.name}] the following files might be published: ${publishableOutputs*.toUriString()}"
 
         // mark task as completed
         completedTasks << task
@@ -323,7 +325,7 @@ class CleanupObserverV2 implements TraceObserver {
             if( path !in publishableOutputs )
                 pathState.published = true
 
-            log.trace "File ${path} may be used by the following processes: ${processConsumersMap[path]}"
+            log.trace "File ${path} might be used by the following processes: ${processConsumersMap[path]}"
             paths[path] = pathState
         }
 
@@ -372,7 +374,8 @@ class CleanupObserverV2 implements TraceObserver {
 
         for( final entry : task.getOutputsByType(FileOutParam) ) {
             final param = entry.key
-            final publishable = processState.publishable[param.index]
+            if( !processState.publishable[param.index] )
+                continue
             final value = entry.value
             if( value instanceof Path )
                 result.add(value)

--- a/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
+++ b/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2024, Ben Sherman
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.boost.cleanup
+
+import java.nio.file.FileSystem
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.locks.Lock
+import java.util.concurrent.locks.ReentrantLock
+
+import groovy.transform.CompileStatic
+import groovy.transform.Memoized
+import groovy.transform.TupleConstructor
+import groovy.util.logging.Slf4j
+import groovyx.gpars.dataflow.DataflowWriteChannel
+import groovyx.gpars.dataflow.operator.DataflowEventAdapter
+import groovyx.gpars.dataflow.operator.DataflowProcessor
+import nextflow.Session
+import nextflow.dag.DAG
+import nextflow.file.FileHelper
+import nextflow.processor.PublishDir
+import nextflow.processor.PublishDir.Mode
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
+import nextflow.trace.TraceObserver
+import nextflow.trace.TraceRecord
+import nextflow.script.params.FileOutParam
+import nextflow.script.params.OutParam
+import nextflow.script.params.TupleOutParam
+import nextflow.util.Duration
+import nextflow.util.Threads
+/**
+ * Delete temporary files once they are no longer needed.
+ *
+ * This implementation uses the workflow publish definition
+ * instead of the publishDir directives.
+ *
+ * @author Ben Sherman <bentshermann@gmail.com>
+ */
+@Slf4j
+@CompileStatic
+class CleanupObserverV2 implements TraceObserver {
+
+    static private final Duration DEF_CLEANUP_INTERVAL = Duration.of('5s')
+
+    private Session session
+
+    private Map<String,ProcessState> processes = [:]
+
+    private Map<Path,PathState> paths = [:]
+
+    private Set<TaskRun> completedTasks = []
+
+    private Set<Path> publishedOutputs = []
+
+    private Lock eventLock = new ReentrantLock()
+
+    private LinkedBlockingQueue<Event> eventQueue = new LinkedBlockingQueue<>()
+
+    private long delayMillis = 5000
+
+    @Override
+    void onFlowCreate(Session session) {
+        this.session = session
+        this.delayMillis = (session.config.navigate('boost.cleanupInterval', DEF_CLEANUP_INTERVAL) as Duration).toMillis()
+
+        if( session.resumeMode )
+            log.warn "This experimental version of automatic cleanup does not work with resume -- deleted tasks will be re-executed"
+    }
+
+    /**
+     * When the workflow begins, determine the consumers of each process
+     * in the DAG.
+     */
+    @Override
+    void onFlowBegin() {
+
+        // prpeare lookup tables
+        final Map<DAG.Vertex,List<DAG.Vertex>> successors = [:]
+        final Map<DataflowWriteChannel,List<DAG.Edge>> edgeLookup = [:]
+        for( def edge : session.dag.edges ) {
+            // lookup vertex -> successor vertices
+            if( edge.from !in successors )
+                successors[edge.from] = []
+            successors[edge.from] << edge.to
+
+            // lookup channel -> edges
+            if( edge.channel !instanceof DataflowWriteChannel )
+                continue
+            final ch = (DataflowWriteChannel)edge.channel
+            if( ch !in edgeLookup )
+                edgeLookup[ch] = []
+            edgeLookup[ch] << edge
+        }
+
+        // construct process lookup
+        final Set<Tuple2<String,Integer>> withForwardedInputs = []
+
+        for( def vertex : session.dag.vertices ) {
+            // skip nodes that are not processes
+            final process = vertex.process
+            if( process == null )
+                continue
+
+            // get the set of consuming processes for each process output
+            final outputs = process.config.getOutputs()
+            final List<Set<String>> consumers = outputs.collect { [] as Set }
+            final List<Boolean> publishable = outputs.collect { false }
+
+            for( int i = 0; i < outputs.size(); i++ ) {
+                final param = outputs[i]
+                final ch = param.getOutChannel()
+
+                // get the set of consuming processes
+                def queue = edgeLookup.getOrDefault(ch, []).collect { edge -> edge.to }
+                while( !queue.isEmpty() ) {
+                    final w = queue.remove(0)
+                    // skip terminal edges
+                    if( !w )
+                        continue
+                    // add operator nodes to the queue to keep searching
+                    if( w.process == null )
+                        queue.addAll( successors[w] )
+                    // add process nodes to the list of consumers
+                    else
+                        consumers[i] << w.process.name
+                }
+
+                // determine whether the output channel might be published
+                if( ch in session.publishTargets )
+                    publishable[i] = true
+
+                // check if output may forward input files
+                if( hasForwardedInputs(param) )
+                    withForwardedInputs << new Tuple2(process.name, i)
+            }
+
+            processes[process.name] = new ProcessState(consumers, publishable)
+
+            // add event listener for process close
+            process.operator.addDataflowEventListener(new DataflowEventAdapter() {
+                @Override
+                void afterStop(final DataflowProcessor processor) {
+                    onProcessClose(process)
+                }
+            })
+        }
+
+        // if a process B receives files from process A and forwards them
+        // as outputs to process C, then process C must be marked as a
+        // consumer of process A even if there is no direct dependency
+        processes.each { processName, processState ->
+            // append indirect consumers (and publishable) for each process output
+            for( int i = 0; i < processState.consumers.size(); i++ ) {
+                final consumers = processState.consumers[i]
+                for( final pair : withForwardedInputs ) {
+                    final consumerName = pair.first
+                    final j = pair.second
+                    if( consumerName in consumers ) {
+                        log.trace "Process output `${consumerName}/${j+1}` may forward output files, marking its consumers as indirect consumers of `${processName}/${i+1}`"
+                        final consumerState = processes[consumerName]
+                        consumers.addAll(consumerState.consumers[j])
+                        processState.publishable[i] |= consumerState.publishable[j]
+                    }
+                }
+
+                log.trace "Process output `${processName}/${i+1}` is used by the following processes: ${processState.consumers[i]}"
+            }
+        }
+
+        // launch thread to handle workflow events and cleanup
+        Threads.start('Task cleanup') {
+            try {
+                while( true ) {
+                    handleEvents()
+                    Thread.sleep(delayMillis)
+                }
+            }
+            catch( Throwable e ) {
+                log.debug "Unexpected error in cleanup observer", e
+            }
+        }
+    }
+
+    /**
+     * Determine whether a process output may forward input files
+     * as outputs.
+     *
+     * TODO: check if a non-glob file output matches a file from this process output
+     *
+     * @param param
+     */
+    private boolean hasForwardedInputs(OutParam param) {
+        if( param instanceof FileOutParam && param.includeInputs )
+            return true
+        if( param instanceof TupleOutParam )
+            return param.inner.any( p -> p instanceof FileOutParam && p.includeInputs )
+        return false
+    }
+
+    /**
+     * Process workflow events and cleanup.
+     */
+    private void handleEvents() {
+        // remove all events from the queue
+        final List<Event> events = []
+
+        eventLock.withLock {
+            eventQueue.drainTo(events)
+        }
+
+        log.trace "Processing ${events.size()} workflow events"
+
+        // process each event
+        boolean cleanup = false
+        for( final event : events ) {
+            if( event instanceof Event.TaskPending ) {
+                onTaskPending0(event.task)
+            }
+            else if( event instanceof Event.TaskCompleted ) {
+                cleanup |= onTaskComplete0(event.task)
+            }
+            else if( event instanceof Event.FilePublished ) {
+                onFilePublish0(event.path)
+            }
+            else if( event instanceof Event.ProcessClosed ) {
+                onProcessClose0(event.process)
+                cleanup = true
+            }
+        }
+
+        // scan for cleanup if needed
+        if( cleanup ) {
+            log.trace "Scanning for cleanup"
+            cleanup0()
+        }
+    }
+
+    /**
+     * When a task is created, mark it as a consumer of its input files.
+     *
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onProcessPending(TaskHandler handler, TraceRecord trace) {
+        eventLock.withLock {
+            eventQueue << new Event.TaskPending(handler.task)
+        }
+    }
+
+    private void onTaskPending0(TaskRun task) {
+        // mark task as consumer of each input file
+        final inputs = task.getInputFilesMap().values()
+        for( Path path : inputs )
+            if( path in paths )
+                paths[path].consumerTasks << task
+    }
+
+    /**
+     * When a task is completed, track the task and its output files
+     * for automatic cleanup.
+     *
+     * @param handler
+     * @param trace
+     */
+    @Override
+    void onProcessComplete(TaskHandler handler, TraceRecord trace) {
+        eventLock.withLock {
+            eventQueue << new Event.TaskCompleted(handler.task)
+        }
+    }
+
+    private boolean onTaskComplete0(TaskRun task) {
+        // mark failed task as completed without scanning for cleanup
+        // TODO: wait for retried task to be pending first
+        if( !task.isSuccess() ) {
+            completedTasks << task
+            return false
+        }
+
+        // query task output files
+        final outputs = task
+            .getOutputsByType(FileOutParam)
+            .values()
+            .flatten() as Set<Path>
+
+        // get process consumers for each file
+        final processConsumersMap = getProcessConsumers(task, outputs)
+
+        // get publishable outputs
+        final publishableOutputs = getPublishableOutputs(task, outputs)
+
+        log.trace "[${task.name}] the following files may be published: ${publishableOutputs*.toUriString()}"
+
+        // mark task as completed
+        completedTasks << task
+
+        // remove any outputs that have already been published
+        final alreadyPublished = publishedOutputs.intersect(publishableOutputs)
+        publishedOutputs.removeAll(alreadyPublished)
+        publishableOutputs.removeAll(alreadyPublished)
+
+        // add each output file to the path state map
+        for( Path path : outputs ) {
+            final pathState = new PathState(task, processConsumersMap[path])
+            if( path !in publishableOutputs )
+                pathState.published = true
+
+            log.trace "File ${path} may be used by the following processes: ${processConsumersMap[path]}"
+            paths[path] = pathState
+        }
+
+        return true
+    }
+
+    /**
+     * Determine the set of process consumers for each output file
+     * of a task based on the output channels that emitted the file.
+     *
+     * @param task
+     * @param outputs
+     */
+    private Map<Path,Set<String>> getProcessConsumers(TaskRun task, Set<Path> outputs) {
+        final Map<Path,Set<String>> result = outputs.inject([:]) { acc, path ->
+            acc[path] = [] as Set
+            acc
+        }
+        final processState = processes[task.processor.name]
+
+        for( final entry : task.getOutputsByType(FileOutParam) ) {
+            final param = entry.key
+            final consumers = processState.consumers[param.index]
+            final value = entry.value
+            if( value instanceof Path )
+                result[value].addAll(consumers)
+            else if( value instanceof Collection<Path> )
+                value.each { el -> result[el].addAll(consumers) }
+            else
+                throw new IllegalArgumentException("Unknown output file object [${value.class.name}]: ${value}")
+        }
+
+        return result
+    }
+
+    /**
+     * Determine the set of task outputs that might be published
+     * based on the output channels that emitted each file.
+     *
+     * @param task
+     * @param outputs
+     */
+    private Set<Path> getPublishableOutputs(TaskRun task, Set<Path> outputs) {
+        final Set<Path> result = []
+        final processState = processes[task.processor.name]
+
+        for( final entry : task.getOutputsByType(FileOutParam) ) {
+            final param = entry.key
+            final publishable = processState.publishable[param.index]
+            final value = entry.value
+            if( value instanceof Path )
+                result.add(value)
+            else if( value instanceof Collection<Path> )
+                result.addAll(value)
+            else
+                throw new IllegalArgumentException("Unknown output file object [${value.class.name}]: ${value}")
+        }
+
+        return result
+    }
+
+    /**
+     * When a file is published, mark it as published and delete
+     * it if it is no longer needed.
+     *
+     * If the file is published before the corresponding task is
+     * marked as completed, save it for later.
+     *
+     * @param destination
+     * @param source
+     */
+    @Override
+    void onFilePublish(Path destination, Path source) {
+        eventLock.withLock {
+            eventQueue << new Event.FilePublished(source)
+        }
+    }
+
+    private void onFilePublish0(Path path) {
+        // get the corresponding task
+        final pathState = paths[path]
+        if( pathState != null ) {
+            final task = pathState.task
+
+            log.trace "File ${path.toUriString()} was published by task <${task.name}>"
+
+            // mark file as published
+            pathState.published = true
+
+            // delete file if it can be deleted
+            if( canDeleteFile(path) )
+                deleteFile(path)
+        }
+        else {
+            log.trace "File ${path.toUriString()} was published before task was marked as completed"
+
+            // save file to be processed when task completes
+            publishedOutputs << path
+        }
+    }
+
+    /**
+     * When a process is closed (all tasks of the process have been created),
+     * mark the process as closed and scan files for cleanup.
+     *
+     * NOTE: a process may submit additional tasks after it is closed, if a
+     * task fails and is retried. The retried task should be marked as pending
+     * before the failed task is marked as completed.
+     *
+     * @param process
+     */
+    void onProcessClose(TaskProcessor process) {
+        eventLock.withLock {
+            eventQueue << new Event.ProcessClosed(process)
+        }
+    }
+
+    private void onProcessClose0(TaskProcessor process) {
+        processes[process.name].closed = true
+    }
+
+    /**
+     * Process any remaining events and cleanup when the workflow is done.
+     */
+    @Override
+    void onFlowComplete() {
+        handleEvents()
+    }
+
+    /**
+     * Delete any files that can be deleted.
+     */
+    private void cleanup0() {
+        for( Path path : paths.keySet() )
+            if( canDeleteFile(path) )
+                deleteFile(path)
+    }
+
+    /**
+     * Determine whether a file can be deleted.
+     *
+     * A file can be deleted if:
+     * - the file has been published (or doesn't need to be published)
+     * - the file hasn't already been deleted
+     * - all of its process consumers are closed
+     * - all of its task consumers are completed
+     *
+     * @param path
+     */
+    private boolean canDeleteFile(Path path) {
+        final pathState = paths[path]
+
+        pathState.published
+            && !pathState.deleted
+            && pathState.consumerProcesses.every( p -> processes[p].closed )
+            && pathState.consumerTasks.every( t -> t in completedTasks )
+    }
+
+    /**
+     * Delete a file.
+     *
+     * @param path
+     */
+    private void deleteFile(Path path) {
+        final pathState = paths[path]
+        final task = pathState.task
+
+        log.trace "[${task.name}] Deleting file: ${path.toUriString()}"
+        FileHelper.deletePath(path)
+        pathState.deleted = true
+    }
+
+    static private class ProcessState {
+        List<Set<String>> consumers
+        List<Boolean> publishable
+        boolean closed = false
+
+        ProcessState(List<Set<String>> consumers, List<Boolean> publishable) {
+            this.consumers = consumers
+            this.publishable = publishable
+        }
+    }
+
+    static private class PathState {
+        TaskRun task
+        Set<String> consumerProcesses
+        Set<TaskRun> consumerTasks = []
+        boolean deleted = false
+        boolean published = false
+
+        PathState(TaskRun task, Set<String> consumerProcesses) {
+            this.task = task
+            this.consumerProcesses = consumerProcesses
+        }
+    }
+
+    static private interface Event {
+        @TupleConstructor
+        static class TaskPending implements Event {
+            TaskRun task
+        }
+        @TupleConstructor
+        static class TaskCompleted implements Event {
+            TaskRun task
+        }
+        @TupleConstructor
+        static class FilePublished implements Event {
+            Path path
+        }
+        @TupleConstructor
+        static class ProcessClosed implements Event {
+            TaskProcessor process
+        }
+    }
+
+}

--- a/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
+++ b/plugins/nf-boost/src/main/nextflow/boost/cleanup/CleanupObserverV2.groovy
@@ -128,7 +128,7 @@ class CleanupObserverV2 implements TraceObserver {
                 final ch = param.getOutChannel()
 
                 // get the set of consuming processes
-                def queue = edgeLookup.getOrDefault(ch, []).collect { edge -> edge.to }
+                final queue = edgeLookup.getOrDefault(ch, []).collect { edge -> edge.to }
                 while( !queue.isEmpty() ) {
                     final w = queue.remove(0)
                     // skip terminal edges


### PR DESCRIPTION
This PR adds a new cleanup observer that uses the workflow output definition instead of publishDir. It can be enabled by setting `boost.cleanup = 'v2'` in the config.

Initial testing suggests the v2 cleanup isn't quite on par with v1 yet:

![disk-usage](https://github.com/user-attachments/assets/28911dd0-4ecf-4157-a899-9812e369ce7d)
