### PR TITLE
Add `filterMap` operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Currently includes the following features:
 
 - `exec` operator for creating an inline native (i.e. `exec`) process
 
+- `filterMap` operator for filtering and mapping in a single operation
+
 - `mergeCsv` function for saving records to a CSV file
 
 - `mergeText` function for saving items to a text file (similar to `collectFile` operator)
@@ -122,6 +124,10 @@ Limitations:
 - Inline process directives are not supported yet.
 
 - The inline exec body should accept a single value and return a single value. Multiple inputs/outputs are not supported yet.
+
+**`filterMap( mapper )`**
+
+The `filterMap` operator is a combination of `filter` and `map`. It applies a mapping function to each value in a source channel. The mapping function should return an [Optional](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Optional.html) -- non-empty optionals are unwrapped and emitted, while empty optionals are not emitted.
 
 **`scan( [seed], accumulator )`**
 

--- a/examples/filter-map.nf
+++ b/examples/filter-map.nf
@@ -1,0 +1,16 @@
+
+include { filterMap } from 'plugin/nf-boost'
+
+workflow {
+  Channel.fromList( 1..15 )
+    .filterMap { n ->
+      if( n % 15 == 0 )
+        return Optional.of("${n}: FizzBuzz")
+      if( n % 3 == 0 )
+        return Optional.of("${n}: Fizz")
+      if( n % 5 == 0 )
+        return Optional.of("${n}: Buzz")
+      return Optional.empty()
+    }
+    .view()
+}


### PR DESCRIPTION
The `filterMap` operator is like `branch` but for a single output. It allows you to define a filtering condition and mapping expression in a single operator.

I'm considering this alternative so that we might eventually phase out `branch` (and `multiMap`) so that we don't have to support the special closure-with-labels syntax that they use, which creates some challenges for some kinds of syntax errors.